### PR TITLE
Added prepare.bat and fixed VS compiler errors caused by bad ordered include files

### DIFF
--- a/nethack-cn/prepare.bat
+++ b/nethack-cn/prepare.bat
@@ -1,0 +1,13 @@
+:: Requires GnuWin32 iconv, mv
+SETLOCAL ENABLEEXTENSIONS
+
+REM switch to this file's directory
+CD /d "%0\.." 1>NUL 2>&1
+
+FOR %%X IN (src\*.*, include\artilist.h, dat\*.*, win\win32\*.c) DO (
+	iconv.exe -c -f utf-8 -t gb18030 %%X 1> %%X.gb
+	mv.exe %%X.gb %%X
+)
+
+CALL sys\winnt\nhsetup.bat
+ENDLOCAL

--- a/nethack-cn/sys/share/cppregex.cpp
+++ b/nethack-cn/sys/share/cppregex.cpp
@@ -8,7 +8,8 @@
 /* nhregex interface documented in sys/share/posixregex.c */
 
 extern "C" {
-  #include <hack.h>
+  #include <config.h>
+  #include <global.h>
 
   extern const char regex_id[] = "cppregex";
 

--- a/nethack-cn/sys/share/pcmain.c
+++ b/nethack-cn/sys/share/pcmain.c
@@ -4,9 +4,6 @@
 
 /* main.c - MSDOS, OS/2, ST, Amiga, and Windows NetHack */
 
-#include "hack.h"
-#include "dlb.h"
-
 #ifndef NO_SIGNAL
 #include <signal.h>
 #endif
@@ -28,6 +25,9 @@
 #ifdef __DJGPP__
 #include <unistd.h> /* for getcwd() prototype */
 #endif
+
+#include "hack.h"
+#include "dlb.h"
 
 char orgdir[PATHLEN]; /* also used in pcsys.c, amidos.c */
 

--- a/nethack-cn/sys/winnt/nhdefkey.c
+++ b/nethack-cn/sys/winnt/nhdefkey.c
@@ -19,9 +19,9 @@
 static char where_to_get_source[] = "http://www.nethack.org/";
 static char author[] = "The NetHack Development Team";
 
+#include "win32api.h"
 #include "hack.h"
 #include "wintty.h"
-#include "win32api.h"
 
 extern HANDLE hConIn;
 extern INPUT_RECORD ir;

--- a/nethack-cn/sys/winnt/ntsound.c
+++ b/nethack-cn/sys/winnt/ntsound.c
@@ -10,9 +10,9 @@
  *
  */
 
-#include "hack.h"
 #include "win32api.h"
 #include <mmsystem.h>
+#include "hack.h"
 
 #ifdef USER_SOUNDS
 

--- a/nethack-cn/sys/winnt/nttty.c
+++ b/nethack-cn/sys/winnt/nttty.c
@@ -14,11 +14,11 @@
 
 #ifdef WIN32
 #define NEED_VARARGS /* Uses ... */
-#include "hack.h"
-#include "wintty.h"
 #include <sys\types.h>
 #include <sys\stat.h>
 #include "win32api.h"
+#include "hack.h"
+#include "wintty.h"
 
 void FDECL(cmov, (int, int));
 void FDECL(nocmov, (int, int));

--- a/nethack-cn/sys/winnt/winnt.c
+++ b/nethack-cn/sys/winnt/winnt.c
@@ -10,13 +10,13 @@
  */
 
 #define NEED_VARARGS
-#include "hack.h"
 #include <dos.h>
 #ifndef __BORLANDC__
 #include <direct.h>
 #endif
 #include <ctype.h>
 #include "win32api.h"
+#include "hack.h"
 #include "wintty.h"
 #ifdef WIN32
 

--- a/nethack-cn/win/share/tile2bmp.c
+++ b/nethack-cn/win/share/tile2bmp.c
@@ -12,11 +12,11 @@
 
 /* #pragma warning(4103:disable) */
 
-#include "hack.h"
-#include "tile.h"
 #ifndef __GNUC__
 #include "win32api.h"
 #endif
+#include "hack.h"
+#include "tile.h"
 
 #if (TILE_X == 32)
 #define COLORS_IN_USE 256

--- a/nethack-cn/win/win32/mswproc.c
+++ b/nethack-cn/win/win32/mswproc.c
@@ -7,11 +7,11 @@
  * code in the mswin port and the rest of the nethack game engine.
 */
 
+#include "winMS.h"
+#include <assert.h>
 #include "hack.h"
 #include "dlb.h"
 #include "func_tab.h" /* for extended commands */
-#include "winMS.h"
-#include <assert.h>
 #include "mhmap.h"
 #include "mhstatus.h"
 #include "mhtext.h"


### PR DESCRIPTION
关于**sys\winnt\Win编译说明.txt**步骤的修改：

> 1.将以下文件全部更换编码为ANSI

采用新增的preprare.bat自动处理

> 2.双击sys/winnt/nhsetup.bat

在prepare.bat末尾自动调用

> 3.修改include/extern.h文件terminate()参数定义

这是系统定义和应用程序定义冲突导致，应通过调整#include系统头文件和应用程序头文件的顺序解决。