### PR TITLE
修复: cdefs.h 错误

### DIFF
--- a/NetHack/include/tradstdc.h
+++ b/NetHack/include/tradstdc.h
@@ -431,7 +431,7 @@ typedef genericptr genericptr_t; /* (void *) or (char *) */
 #define NORETURN __attribute__((noreturn))
 /* disable gcc's __attribute__((__warn_unused_result__)) since explicitly
    discarding the result by casting to (void) is not accepted as a 'use' */
-#define __warn_unused_result__ /*empty*/
+#define __warn_unused_result__ __unused__ 
 #define warn_unused_result /*empty*/
 #endif
 #endif


### PR DESCRIPTION
感觉可能是glibc版本问题，ubuntu 22.04会出现这个问题
```
/usr/include/x86_64-linux-gnu/sys/cdefs.h:405:73: error: macro "__has_attribute" requires an identifier
  405 | #if __GNUC_PREREQ (3,4) || __glibc_has_attribute (__warn_unused_result__)
      | 
```